### PR TITLE
Update Dockerfile to use mkimage from new path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir -p /${GITHUB_REPOSITORY}
 WORKDIR /${GITHUB_REPOSITORY}
 ADD / /${GITHUB_REPOSITORY}/
 RUN ${BUILD_COMMAND}
-RUN bin/mkimage
+RUN beam-docker-release-action/mkimage
 
 
 FROM scratch


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker build process to use an alternative build script invocation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->